### PR TITLE
Merge upgrades from Pico 1.0 release

### DIFF
--- a/includes/class.setup.php
+++ b/includes/class.setup.php
@@ -46,7 +46,7 @@ class Pico_Setup {
     * @return [string] widget endpoint
     */
     public static function get_widget_endpoint() {
-        return defined('PP_WIDGET_ENDPOINT') ? PP_WIDGET_ENDPOINT : 'https://widget.pico.tools';
+        return defined('PP_WIDGET_ENDPOINT') ? PP_WIDGET_ENDPOINT : 'https://gadget.pico.tools';
     }
 
     /**
@@ -111,10 +111,10 @@ class Pico_Setup {
     /**
      * Gets the Pico Context
      * 
-     * @return [string] gadget or widget, default to widget
+     * @return [string] gadget or widget, default to gadget
      */
     public static function get_pico_context(){
-        return defined('PICO_CONTEXT') ? PICO_CONTEXT : 'widget';
+        return defined('PICO_CONTEXT') ? PICO_CONTEXT : 'gadget';
     }
 
     /**

--- a/pico.php
+++ b/pico.php
@@ -3,13 +3,13 @@
  * Plugin Name: Pico
  * Plugin URI:  https://github.com/PicoNetworks/wordpress-plugin
  * Description: Signup and payment tools for the internet's most passionate communities
- * Version:     0.9.4
+ * Version:     1.0.0
  * Author:      picoengineering
  * Author URI:  https://trypico.com
  * License:     GPL2
  */
 
-define( 'PICO_VERSION', '0.9.4' );
+define( 'PICO_VERSION', '1.0.0' );
 define( 'PICO__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PICO__MINIMUM_WP_VERSION', '3.7' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: picoengineering
 Tags: subscriptions, memberships, stripe
 Requires at least: 3.7
-Tested up to: 5.5.1
+Tested up to: 5.6
 Requires PHP: 5.2.4
-Stable tag: 0.9.4
+Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,10 @@ Complete instructions for using Pico, including product tours, troubleshooting, 
 6. Target registration and monetization popups at just the right moment.
 
 == Changelog ==
+
+= 1.0.0 =
+* Support for new Pico Gadget!
+* Support for WP 5.6
 
 = 0.9.4 =
 Minor enhancements


### PR DESCRIPTION
This merges all updates from the 1.0.0 release of the Pico plugin to our fork. We still need to maintain this fork while their plugin includes an override of the `rest_send_cors_headers()` function in WordPress core.

**Changes**

* Updates the widget endpoint URL to `https://gadget.pico.tools`
* Bumps version numbers

