### PR TITLE
Merge updates from version 1.0.1

### DIFF
--- a/pico.php
+++ b/pico.php
@@ -3,13 +3,13 @@
  * Plugin Name: Pico
  * Plugin URI:  https://github.com/PicoNetworks/wordpress-plugin
  * Description: Signup and payment tools for the internet's most passionate communities
- * Version:     1.0.0
+ * Version:     1.0.1
  * Author:      picoengineering
  * Author URI:  https://trypico.com
  * License:     GPL2
  */
 
-define( 'PICO_VERSION', '1.0.0' );
+define( 'PICO_VERSION', '1.0.1' );
 define( 'PICO__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PICO__MINIMUM_WP_VERSION', '3.7' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: subscriptions, memberships, stripe
 Requires at least: 3.7
 Tested up to: 5.6
 Requires PHP: 5.2.4
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,9 @@ Complete instructions for using Pico, including product tours, troubleshooting, 
 6. Target registration and monetization popups at just the right moment.
 
 == Changelog ==
+
+= 1.0.1 =
+Minor cleanup
 
 = 1.0.0 =
 * Support for new Pico Gadget!


### PR DESCRIPTION
The minor updates referenced were a few lines of code we suggested as cleanup, so they don't appear in the diff here.

The only code block that now differs in our fork vs their original is the removal of their CORS headers customizations that are overly broad.